### PR TITLE
UX: Simplify part card editor settings

### DIFF
--- a/docs/content-authoring.md
+++ b/docs/content-authoring.md
@@ -378,7 +378,7 @@ The editor can:
 - delete a section and all of its parts;
 - add and edit parts;
 - move, rename, and reorder parts;
-- search for and download a part image.
+- search for a part image or download one directly from a public URL.
 
 Editor saves write directly to `src/content/builds/guides`. Refresh after a
 successful save to load the rebuilt content modules. Image search results come

--- a/src/components/build-guides/PartCardView.svelte
+++ b/src/components/build-guides/PartCardView.svelte
@@ -20,6 +20,7 @@
 		image,
 		imageAlt,
 		Description,
+		descriptionText,
 		onaddtolist,
 		actions,
 		footer
@@ -31,7 +32,8 @@
 		tags: BuildGuidePartTag[]
 		image: Picture | null
 		imageAlt: string
-		Description: Component
+		Description?: Component
+		descriptionText?: string
 		onaddtolist?: () => void
 		actions?: Snippet
 		footer?: Snippet
@@ -74,7 +76,11 @@
 		priceClass={colors.price}
 	/>
 	<div class="prose">
-		<Description />
+		{#if Description}
+			<Description />
+		{:else if descriptionText}
+			<p class="whitespace-pre-wrap">{descriptionText}</p>
+		{/if}
 	</div>
 	{@render footer?.()}
 </PartCardFrame>

--- a/src/components/build-guides/editor/EditablePartCard.svelte
+++ b/src/components/build-guides/editor/EditablePartCard.svelte
@@ -20,8 +20,18 @@
 		BuildGuidePart,
 		BuildGuideSection
 	} from "$lib/build-guides/types"
-	import { ChevronUp, Eye, Loader2, Pencil, Save } from "@lucide/svelte"
 	import { toastError, toastSuccess } from "$lib/toaster"
+	import { Dialog, Portal } from "@skeletonlabs/skeleton-svelte"
+	import {
+		ChevronUp,
+		Download,
+		Eye,
+		Loader2,
+		Pencil,
+		Save,
+		Settings2,
+		X
+	} from "@lucide/svelte"
 	import { tick, untrack } from "svelte"
 	import { slide } from "svelte/transition"
 
@@ -37,6 +47,8 @@
 		url: string
 		color: BuildGuidePartAccent
 		imageFormat: ImageFormat | ""
+		imageFilenameStem: string
+		imageAlt: string
 		sectionSlug: string
 		price: string
 		tagsInput: string
@@ -81,6 +93,9 @@
 	let order = $state(1)
 	let color = $state<BuildGuidePartAccent>("success")
 	let imageFormat = $state<ImageFormat | "">("")
+	let imageFilenameStem = $state("")
+	let imageAlt = $state("")
+	let manualImageUrl = $state("")
 	let sectionSlug = $state("")
 	let price = $state("")
 	let tagsInput = $state("")
@@ -91,6 +106,8 @@
 	let originalSectionSlug = $state("")
 	let originalSnapshot = $state("")
 	let saving = $state(false)
+	let downloadingManualImage = $state(false)
+	let settingsOpen = $state(false)
 
 	const colors = $derived(buildGuidePartAccentClasses[color])
 
@@ -98,12 +115,17 @@
 	const newPartDraftKey = $derived(
 		`build-guide-new-part:${guideSlug}:${section.id}`
 	)
+	const manualImageUrlId = $derived(
+		`manual-image-url-${part?.id ?? `${guideSlug}-${section.id}-new`}`
+	)
 	const newPartDraft = $derived(
 		JSON.stringify({
 			title,
 			url,
 			color,
 			imageFormat,
+			imageFilenameStem,
+			imageAlt,
 			sectionSlug,
 			price,
 			tagsInput,
@@ -121,7 +143,13 @@
 	const previewPrice = $derived(price.trim() || undefined)
 
 	const imageFilename = $derived(
-		imageFormat && slug.trim() ? `${slug.trim()}.${imageFormat}` : undefined
+		imageFormat && (imageFilenameStem || slug.trim())
+			? `${imageFilenameStem || slug.trim()}.${imageFormat}`
+			: undefined
+	)
+	const slugValid = $derived(/^[a-z0-9-]+$/.test(slug.trim()))
+	const canDownloadManualImage = $derived(
+		manualImageUrl.trim().length > 0 && slugValid && !downloadingManualImage
 	)
 
 	const currentSnapshot = $derived(
@@ -130,7 +158,8 @@
 			url,
 			order,
 			color,
-			imageFormat,
+			imageFilename,
+			imageAlt,
 			price,
 			tagsInput,
 			body,
@@ -142,7 +171,7 @@
 	const canSave = $derived(
 		title.trim().length > 0 &&
 			url.trim().length > 0 &&
-			slug.trim().length > 0 &&
+			slugValid &&
 			(isNew || currentSnapshot !== originalSnapshot)
 	)
 
@@ -153,6 +182,8 @@
 
 	const controlClass =
 		"rounded-md bg-surface-500/10 text-sm break-all px-2 py-1"
+	const dialogAnimation =
+		"transition transition-discrete opacity-0 starting:data-[state=open]:opacity-0 data-[state=open]:opacity-100"
 
 	function nextOrderForSection(targetSectionSlug: string): number {
 		const targetSection = sections.find(
@@ -185,6 +216,9 @@
 				typeof draft.url !== "string" ||
 				typeof draft.color !== "string" ||
 				typeof draft.imageFormat !== "string" ||
+				(draft.imageFilenameStem !== undefined &&
+					typeof draft.imageFilenameStem !== "string") ||
+				(draft.imageAlt !== undefined && typeof draft.imageAlt !== "string") ||
 				typeof draft.sectionSlug !== "string" ||
 				typeof draft.price !== "string" ||
 				typeof draft.tagsInput !== "string" ||
@@ -197,7 +231,11 @@
 				return null
 			}
 
-			return draft as NewPartDraft
+			return {
+				...draft,
+				imageFilenameStem: draft.imageFilenameStem ?? "",
+				imageAlt: draft.imageAlt ?? ""
+			} as NewPartDraft
 		} catch {
 			return null
 		}
@@ -208,6 +246,9 @@
 	}
 
 	function resetFromPart(nextPart: BuildGuidePart | null) {
+		settingsOpen = false
+		manualImageUrl = ""
+
 		if (!nextPart) {
 			const draft = getNewPartDraft()
 			editMode = true
@@ -218,6 +259,8 @@
 			order = nextOrderForSection(sectionSlug)
 			color = draft?.color ?? "success"
 			imageFormat = draft?.imageFormat ?? ""
+			imageFilenameStem = draft?.imageFilenameStem ?? ""
+			imageAlt = draft?.imageAlt ?? ""
 			price = draft?.price ?? ""
 			tagsInput = draft?.tagsInput ?? ""
 			body = draft?.body ?? ""
@@ -229,7 +272,8 @@
 				url: "",
 				order,
 				color: "success",
-				imageFormat: "",
+				imageFilename: undefined,
+				imageAlt: "",
 				price: "",
 				tagsInput: "",
 				body: "",
@@ -249,6 +293,8 @@
 		imageFormat = nextPart.imageFilename
 			? parseImageFormat(nextPart.imageFilename)
 			: ""
+		imageFilenameStem = nextPart.imageFilename?.replace(/\.[^.]+$/, "") ?? ""
+		imageAlt = nextPart.imageAlt
 		price = nextPart.price ?? ""
 		tagsInput = formatParsedBuildGuideTags(nextPart.tags)
 		body = getBuildGuidePartSource(
@@ -264,9 +310,8 @@
 			url: nextPart.url,
 			order: nextPart.order,
 			color: nextPart.accent,
-			imageFormat: nextPart.imageFilename
-				? parseImageFormat(nextPart.imageFilename)
-				: "",
+			imageFilename: nextPart.imageFilename,
+			imageAlt: nextPart.imageAlt,
 			price: nextPart.price ?? "",
 			tagsInput: formatParsedBuildGuideTags(nextPart.tags),
 			body: getBuildGuidePartSource(
@@ -289,7 +334,7 @@
 
 	function handleTitleInput(event: Event) {
 		const nextTitle = (event.currentTarget as HTMLInputElement).value
-		if (nextTitle) slug = slugifyBuildGuideTitle(nextTitle)
+		if (isNew && nextTitle) slug = slugifyBuildGuideTitle(nextTitle)
 	}
 
 	function handleSectionChange(event: Event) {
@@ -337,6 +382,7 @@
 				color,
 				price: price.trim() || undefined,
 				image: imageFilename,
+				imageAlt: imageAlt.trim() || undefined,
 				tags,
 				body
 			})
@@ -388,6 +434,7 @@
 		extension: string
 		path: string
 	}) {
+		imageFilenameStem = slug.trim()
 		imageFormat = parseImageFormat(`image.${result.extension}`)
 
 		if (isNew) {
@@ -398,7 +445,47 @@
 		}
 
 		await tick()
-		await savePart()
+		if (canSave) await savePart()
+		else toastSuccess({ title: `Downloaded ${result.path}.` })
+	}
+
+	async function downloadManualImage() {
+		if (!canDownloadManualImage) return
+
+		downloadingManualImage = true
+
+		try {
+			const response = await fetch("/api/dev/download-build-image", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					guideSlug,
+					partSlug: slug.trim(),
+					imageUrl: manualImageUrl.trim()
+				})
+			})
+			const payload = (await response.json().catch(() => null)) as {
+				extension?: string
+				path?: string
+				message?: string
+			} | null
+			if (!response.ok || !payload?.extension || !payload.path) {
+				throw new Error(payload?.message ?? "Image download failed")
+			}
+
+			manualImageUrl = ""
+			await handleImageDownload({
+				extension: payload.extension,
+				path: payload.path
+			})
+		} catch (reason) {
+			toastError({
+				title:
+					reason instanceof Error ? reason.message : "Image download failed"
+			})
+		} finally {
+			downloadingManualImage = false
+		}
 	}
 </script>
 
@@ -493,17 +580,14 @@
 				transition:slide
 				onoutroend={finishExitEditMode}
 			>
-				<div class="flex min-w-0 flex-wrap items-center gap-2">
-					<select
-						value={sectionSlug}
-						onchange={handleSectionChange}
+				<div class="flex min-w-0 items-center gap-2">
+					<input
+						type="url"
+						bind:value={url}
+						spellcheck="false"
 						class="{controlClass} min-w-0 flex-1"
-					>
-						{#each sections as entry (entry.id)}
-							<option value={entry.id}>{entry.title}</option>
-						{/each}
-					</select>
-
+						placeholder="https://example.com"
+					/>
 					<div
 						class="flex shrink-0 gap-1"
 						role="radiogroup"
@@ -524,61 +608,200 @@
 						{/each}
 					</div>
 
-					<div class="flex shrink-0">
-						<input
-							type="number"
-							min="1"
-							max="69"
-							bind:value={order}
-							class="no-spinner h-8 w-12 rounded-md bg-surface-500/10 p-2 text-base outline-none focus-within:outline-2 focus-within:outline-current"
-						/>
-						<div
-							class="ml-1 flex h-8 flex-col justify-between text-surface-500/40"
-						>
-							<button
-								type="button"
-								class="hover:text-current {colors.text}"
-								aria-label="Increase order"
-								onclick={() => order++}
-							>
-								<ChevronUp class="size-3 stroke-3" />
-							</button>
-							<button
-								type="button"
-								class="rotate-180 hover:text-current {colors.text}"
-								aria-label="Decrease order"
-								onclick={() => order > 1 && order--}
-							>
-								<ChevronUp class="size-3 stroke-3" />
-							</button>
-						</div>
-					</div>
-				</div>
-
-				<div class="flex min-w-0 gap-2">
-					<input
-						type="url"
-						bind:value={url}
-						spellcheck="false"
-						class="{controlClass} min-w-0 flex-1"
-						placeholder="https://example.com"
-					/>
-					<select
-						bind:value={imageFormat}
-						class="{controlClass} shrink-0"
-						aria-label="Image format"
-					>
-						<option value="">No image</option>
-						{#each imageFormats as format (format)}
-							<option value={format}>{format}</option>
-						{/each}
-					</select>
 					<ImageDownloader
 						{guideSlug}
 						{title}
 						partSlug={slug}
 						ondownload={handleImageDownload}
 					/>
+
+					<Dialog
+						open={settingsOpen}
+						onOpenChange={(details: { open: boolean }) =>
+							(settingsOpen = details.open)}
+					>
+						<Dialog.Trigger
+							type="button"
+							class="rounded-md bg-surface-500/10 p-1.5 text-surface-500 transition-colors hover:bg-surface-500/20 hover:text-current"
+							aria-label="Part settings"
+						>
+							<Settings2 class="size-5" />
+						</Dialog.Trigger>
+
+						<Portal>
+							<Dialog.Backdrop
+								class="fixed inset-0 z-50 bg-surface-50-950/80 backdrop-blur-sm"
+							/>
+							<Dialog.Positioner
+								class="fixed inset-0 z-50 flex items-center justify-center p-4"
+							>
+								<Dialog.Content
+									class="flex max-h-[calc(100svh-2rem)] w-[min(48rem,calc(100vw-2rem))] flex-col overflow-hidden rounded-2xl border border-surface-100-900 bg-surface-50-950 shadow-2xl {dialogAnimation}"
+								>
+									<header
+										class="flex items-center justify-between gap-2 border-b border-surface-500/20 p-4"
+									>
+										<Dialog.Title class="text-lg font-semibold"
+											>Part settings</Dialog.Title
+										>
+										<Dialog.CloseTrigger
+											class="rounded-full p-1 text-surface-500 transition-colors hover:bg-surface-500/10 hover:text-current"
+											aria-label="Close part settings"
+										>
+											<X class="size-6" />
+										</Dialog.CloseTrigger>
+									</header>
+
+									<div
+										class="grid gap-4 overflow-y-auto p-4 md:grid-cols-2 md:gap-0"
+									>
+										<fieldset class="flex flex-col gap-4 md:pr-4">
+											<legend class="mb-2 font-semibold">General</legend>
+
+											<label class="flex flex-col gap-1 text-sm font-medium">
+												Category
+												<select
+													value={sectionSlug}
+													onchange={handleSectionChange}
+													class="{controlClass} w-full font-normal"
+												>
+													{#each sections as entry (entry.id)}
+														<option value={entry.id}>{entry.title}</option>
+													{/each}
+												</select>
+											</label>
+
+											<label class="flex flex-col gap-1 text-sm font-medium">
+												Slug
+												<input
+													type="text"
+													bind:value={slug}
+													spellcheck="false"
+													pattern="[a-z0-9-]+"
+													aria-invalid={!slugValid}
+													class="{controlClass} w-full font-normal"
+													placeholder="part-name"
+												/>
+												<span class="font-normal text-surface-500">
+													Use lowercase letters, numbers, and hyphens. Changing
+													an existing slug also changes its saved ID.
+												</span>
+											</label>
+
+											<div class="flex flex-col gap-1 text-sm font-medium">
+												<span>Order</span>
+												<div class="flex items-center">
+													<input
+														type="number"
+														min="1"
+														max="69"
+														bind:value={order}
+														class="no-spinner h-8 w-16 rounded-md bg-surface-500/10 p-2 text-base font-normal outline-none focus-within:outline-2 focus-within:outline-current"
+													/>
+													<div
+														class="ml-1 flex h-8 flex-col justify-between text-surface-500/40"
+													>
+														<button
+															type="button"
+															class="hover:text-current {colors.text}"
+															aria-label="Increase order"
+															onclick={() => order++}
+														>
+															<ChevronUp class="size-3 stroke-3" />
+														</button>
+														<button
+															type="button"
+															class="rotate-180 hover:text-current {colors.text}"
+															aria-label="Decrease order"
+															onclick={() => order > 1 && order--}
+														>
+															<ChevronUp class="size-3 stroke-3" />
+														</button>
+													</div>
+												</div>
+												<p class="font-normal text-surface-500">
+													Assigned automatically for new parts.
+												</p>
+											</div>
+										</fieldset>
+
+										<fieldset
+											class="flex flex-col gap-4 border-t border-surface-500/20 pt-4 md:border-t-0 md:border-l md:pt-0 md:pl-4"
+										>
+											<legend class="mb-2 font-semibold">Image</legend>
+
+											<label class="flex flex-col gap-1 text-sm font-medium">
+												Format
+												<select
+													bind:value={imageFormat}
+													class="{controlClass} w-full font-normal"
+												>
+													<option value="">No image</option>
+													{#each imageFormats as format (format)}
+														<option value={format}>{format}</option>
+													{/each}
+												</select>
+											</label>
+
+											<label class="flex flex-col gap-1 text-sm font-medium">
+												Alt text
+												<input
+													type="text"
+													bind:value={imageAlt}
+													class="{controlClass} w-full font-normal"
+													placeholder={title.trim() || "Describe the image"}
+												/>
+												<span class="font-normal text-surface-500">
+													Defaults to the part title.
+												</span>
+											</label>
+
+											<div class="flex flex-col gap-1 text-sm font-medium">
+												<label for={manualImageUrlId}>Source URL</label>
+												<div class="flex min-w-0 gap-2">
+													<input
+														id={manualImageUrlId}
+														type="url"
+														bind:value={manualImageUrl}
+														class="{controlClass} min-w-0 flex-1 font-normal"
+														placeholder="https://example.com/image.jpg"
+														onkeydown={(event) =>
+															event.key === "Enter" && downloadManualImage()}
+													/>
+													<button
+														type="button"
+														class="btn shrink-0 gap-2 preset-filled-surface-100-900"
+														disabled={!canDownloadManualImage}
+														onclick={downloadManualImage}
+													>
+														{#if downloadingManualImage}
+															<Loader2 class="size-4 animate-spin" />
+														{:else}
+															<Download class="size-4" />
+														{/if}
+														Replace
+													</button>
+												</div>
+												<p class="font-normal text-surface-500">
+													Downloads the image into this guide's local assets.
+												</p>
+											</div>
+										</fieldset>
+									</div>
+
+									<footer
+										class="flex justify-end border-t border-surface-500/20 p-4"
+									>
+										<Dialog.CloseTrigger
+											class="btn preset-filled-surface-100-900"
+										>
+											Done
+										</Dialog.CloseTrigger>
+									</footer>
+								</Dialog.Content>
+							</Dialog.Positioner>
+						</Portal>
+					</Dialog>
 				</div>
 
 				<textarea

--- a/src/components/build-guides/editor/EditablePartCard.svelte
+++ b/src/components/build-guides/editor/EditablePartCard.svelte
@@ -18,6 +18,7 @@
 	import { parseBuildGuidePartTag } from "$lib/build-guides/tags"
 	import type {
 		BuildGuidePart,
+		BuildGuidePartTag,
 		BuildGuideSection
 	} from "$lib/build-guides/types"
 	import { toastError, toastSuccess } from "$lib/toaster"
@@ -54,6 +55,11 @@
 		tagsInput: string
 		body: string
 		slug: string
+	}
+
+	type TagDraft = {
+		id: number
+		value: string
 	}
 
 	const lastAssignedOrderBySection: Record<string, number> = {}
@@ -98,7 +104,7 @@
 	let manualImageUrl = $state("")
 	let sectionSlug = $state("")
 	let price = $state("")
-	let tagsInput = $state("")
+	let tagDrafts = $state<TagDraft[]>([])
 	let orderSectionSlug = $state<string | null>(null)
 	let body = $state("")
 	let slug = $state("")
@@ -108,6 +114,9 @@
 	let saving = $state(false)
 	let downloadingManualImage = $state(false)
 	let settingsOpen = $state(false)
+	let previewMode = $state(false)
+	let tagsPreviewMode = $state(false)
+	let nextTagId = 0
 
 	const colors = $derived(buildGuidePartAccentClasses[color])
 
@@ -118,6 +127,10 @@
 	const manualImageUrlId = $derived(
 		`manual-image-url-${part?.id ?? `${guideSlug}-${section.id}-new`}`
 	)
+	const rawTags = $derived(
+		tagDrafts.map((tag) => tag.value.trim()).filter(Boolean)
+	)
+	const tagsInput = $derived(rawTags.join("\n"))
 	const newPartDraft = $derived(
 		JSON.stringify({
 			title,
@@ -134,10 +147,19 @@
 		})
 	)
 
-	const previewTags = $derived(
-		parseBuildGuideTagsInput(tagsInput).map((tag) =>
-			parseBuildGuidePartTag(tag)
+	const invalidTagIds = $derived(
+		new Set(
+			tagDrafts
+				.filter((tag) => tag.value.trim() && !tryParseTag(tag.value.trim()))
+				.map((tag) => tag.id)
 		)
+	)
+	const tagsValid = $derived(invalidTagIds.size === 0)
+	const previewTags = $derived(
+		rawTags.flatMap((tag) => {
+			const parsed = tryParseTag(tag)
+			return parsed ? [parsed] : []
+		})
 	)
 
 	const previewPrice = $derived(price.trim() || undefined)
@@ -172,8 +194,10 @@
 		title.trim().length > 0 &&
 			url.trim().length > 0 &&
 			slugValid &&
+			tagsValid &&
 			(isNew || currentSnapshot !== originalSnapshot)
 	)
+	const canPreview = $derived(tagsValid)
 
 	const fieldClass =
 		"rounded-md bg-surface-500/10 p-0! outline-4 outline-surface-500/10"
@@ -184,6 +208,87 @@
 		"rounded-md bg-surface-500/10 text-sm break-all px-2 py-1"
 	const dialogAnimation =
 		"transition transition-discrete opacity-0 starting:data-[state=open]:opacity-0 data-[state=open]:opacity-100"
+
+	function tryParseTag(rawTag: string): BuildGuidePartTag | null {
+		try {
+			return parseBuildGuidePartTag(rawTag)
+		} catch {
+			return null
+		}
+	}
+
+	function createTagDraft(value: string): TagDraft {
+		return { id: nextTagId++, value }
+	}
+
+	function resetTags(tagsInput: string) {
+		tagDrafts = [
+			...parseBuildGuideTagsInput(tagsInput).map(createTagDraft),
+			createTagDraft("")
+		]
+		tagsPreviewMode = false
+	}
+
+	function finishTagEdit(tag: TagDraft) {
+		const value = tag.value.trim()
+		if (!value) {
+			if (tag.id !== tagDrafts.at(-1)?.id) {
+				tagDrafts = tagDrafts.filter((entry) => entry.id !== tag.id)
+			}
+			return
+		}
+
+		tag.value = value
+	}
+
+	function handleTagInput(tag: TagDraft, event: Event) {
+		tag.value = (event.currentTarget as HTMLInputElement).value
+		if (tag.value && tag.id === tagDrafts.at(-1)?.id) {
+			tagDrafts.push(createTagDraft(""))
+		}
+	}
+
+	async function handleTagKeydown(tag: TagDraft, event: KeyboardEvent) {
+		if (
+			event.key === "Backspace" &&
+			event.altKey &&
+			!event.ctrlKey &&
+			!event.metaKey
+		) {
+			event.preventDefault()
+			const currentInput = event.currentTarget as HTMLInputElement
+			if (tag.id === tagDrafts.at(-1)?.id) {
+				const previousTag = tagDrafts.at(-2)
+				if (!previousTag) return
+
+				tagDrafts = tagDrafts.filter((entry) => entry.id !== previousTag.id)
+				await tick()
+				currentInput.focus()
+				return
+			}
+
+			const tagIndex = tagDrafts.findIndex((entry) => entry.id === tag.id)
+			const previousInput = currentInput.previousElementSibling
+			const nextInput = currentInput.nextElementSibling
+			const focusTarget =
+				tagIndex > 0 && tagIndex === tagDrafts.length - 2
+					? previousInput
+					: nextInput
+			tagDrafts = tagDrafts.filter((entry) => entry.id !== tag.id)
+			await tick()
+			if (focusTarget instanceof HTMLInputElement) focusTarget.focus()
+			return
+		}
+
+		if (event.key !== "Enter") return
+
+		event.preventDefault()
+		if (!(event.currentTarget as HTMLInputElement).value.trim()) return
+
+		const nextInput = (event.currentTarget as HTMLInputElement)
+			.nextElementSibling
+		if (nextInput instanceof HTMLInputElement) nextInput.focus()
+	}
 
 	function nextOrderForSection(targetSectionSlug: string): number {
 		const targetSection = sections.find(
@@ -248,6 +353,7 @@
 	function resetFromPart(nextPart: BuildGuidePart | null) {
 		settingsOpen = false
 		manualImageUrl = ""
+		previewMode = false
 
 		if (!nextPart) {
 			const draft = getNewPartDraft()
@@ -262,7 +368,7 @@
 			imageFilenameStem = draft?.imageFilenameStem ?? ""
 			imageAlt = draft?.imageAlt ?? ""
 			price = draft?.price ?? ""
-			tagsInput = draft?.tagsInput ?? ""
+			resetTags(draft?.tagsInput ?? "")
 			body = draft?.body ?? ""
 			slug = draft?.slug ?? ""
 			originalSlug = ""
@@ -296,7 +402,7 @@
 		imageFilenameStem = nextPart.imageFilename?.replace(/\.[^.]+$/, "") ?? ""
 		imageAlt = nextPart.imageAlt
 		price = nextPart.price ?? ""
-		tagsInput = formatParsedBuildGuideTags(nextPart.tags)
+		resetTags(formatParsedBuildGuideTags(nextPart.tags))
 		body = getBuildGuidePartSource(
 			nextPart.guideSlug,
 			nextPart.sectionSlug,
@@ -346,6 +452,7 @@
 	}
 
 	async function enterEditMode() {
+		previewMode = false
 		editControlsVisible = false
 		editMode = true
 		await tick()
@@ -353,15 +460,24 @@
 	}
 
 	let resetAfterExit = false
+	let previewAfterExit = false
 
-	function exitEditMode(reset = true) {
+	function exitEditMode(reset = true, preview = false) {
 		resetAfterExit = reset
+		previewAfterExit = preview
 		editControlsVisible = false
+	}
+
+	function previewPart() {
+		if (canPreview) exitEditMode(false, true)
 	}
 
 	function finishExitEditMode() {
 		if (resetAfterExit) resetFromPart(part)
-		else editMode = false
+		else {
+			editMode = false
+			previewMode = previewAfterExit
+		}
 
 		editControlsVisible = true
 	}
@@ -370,7 +486,6 @@
 		if (!canSave) return
 
 		const nextSlug = slug.trim()
-		const tags = parseBuildGuideTagsInput(tagsInput)
 
 		saving = true
 
@@ -383,7 +498,7 @@
 				price: price.trim() || undefined,
 				image: imageFilename,
 				imageAlt: imageAlt.trim() || undefined,
-				tags,
+				tags: rawTags,
 				body
 			})
 
@@ -489,16 +604,17 @@
 	}
 </script>
 
-{#if !editMode && !isNew && part}
+{#if previewMode || (!editMode && !isNew && part)}
 	<PartCardView
 		{title}
 		{url}
 		accent={color}
 		price={previewPrice}
 		tags={previewTags}
-		image={part.image}
-		imageAlt={part.imageAlt}
-		Description={part.Content}
+		image={part?.image ?? null}
+		imageAlt={imageAlt.trim() || title}
+		Description={part?.Content}
+		descriptionText={part ? undefined : body}
 		{onaddtolist}
 	>
 		{#snippet actions()}
@@ -539,16 +655,15 @@
 					{/if}
 				</button>
 
-				{#if !isNew}
-					<button
-						type="button"
-						class={colors.iconHover}
-						aria-label="View part"
-						onclick={() => exitEditMode()}
-					>
-						<Eye class="size-6 md:size-7" />
-					</button>
-				{/if}
+				<button
+					type="button"
+					class="{colors.iconHover} disabled:pointer-events-none disabled:opacity-40"
+					aria-label="Preview part"
+					disabled={!canPreview}
+					onclick={previewPart}
+				>
+					<Eye class="size-6 md:size-7" />
+				</button>
 			</div>
 		</div>
 
@@ -560,11 +675,55 @@
 				class="{colors.price} price-tag-input border-0 outline outline-current"
 				placeholder="$0.00"
 			/>
-			<PartTags
-				tags={previewTags}
-				priceClass={colors.price}
-				displayContents
-			/>
+			{#if tagsPreviewMode}
+				<PartTags
+					tags={previewTags}
+					priceClass={colors.price}
+					displayContents
+				/>
+				<button
+					type="button"
+					class="rounded-full bg-surface-500/10 p-1 text-surface-500 transition-colors hover:bg-surface-500/20 hover:text-current"
+					aria-label="Edit tags"
+					onclick={() => (tagsPreviewMode = false)}
+				>
+					<Pencil class="size-3.5" />
+				</button>
+			{:else}
+				{#each tagDrafts as tag, index (tag.id)}
+					<input
+						type="text"
+						value={tag.value}
+						spellcheck="false"
+						aria-label={index === tagDrafts.length - 1
+							? "Add tag. Use label<tooltip> for tooltips. Alt+Backspace removes the previous tag."
+							: `Tag ${index + 1}. Use label<tooltip> for tooltips. Alt+Backspace removes this tag.`}
+						aria-keyshortcuts="Alt+Backspace"
+						aria-invalid={invalidTagIds.has(tag.id)}
+						title={index === tagDrafts.length - 1
+							? "Use label<tooltip> for tooltips. Alt+Backspace removes the previous tag."
+							: "Use label<tooltip> for tooltips. Alt+Backspace removes this tag."}
+						class="tag-chip-input rounded-full border-0 bg-surface-500/10 px-2 py-1 text-[11px] font-medium outline outline-surface-500/25 transition-[background-color,outline-color] focus:bg-surface-500/20 focus:outline-2 focus:outline-surface-500/75 md:text-xs dark:bg-surface-500/20 {invalidTagIds.has(
+							tag.id
+						)
+							? 'text-error-500 outline-error-500/50 focus:outline-error-500'
+							: 'text-surface-900-100'}"
+						placeholder={index === tagDrafts.length - 1 ? "+ tag" : undefined}
+						oninput={(event) => handleTagInput(tag, event)}
+						onkeydown={(event) => handleTagKeydown(tag, event)}
+						onblur={() => finishTagEdit(tag)}
+					/>
+				{/each}
+				<button
+					type="button"
+					class="rounded-full bg-surface-500/10 p-1 text-surface-500 transition-colors hover:bg-surface-500/20 hover:text-current disabled:pointer-events-none disabled:opacity-40"
+					aria-label="Preview tags"
+					disabled={!tagsValid}
+					onclick={() => (tagsPreviewMode = true)}
+				>
+					<Eye class="size-3.5" />
+				</button>
+			{/if}
 		</div>
 
 		<textarea
@@ -803,14 +962,6 @@
 						</Portal>
 					</Dialog>
 				</div>
-
-				<textarea
-					bind:value={tagsInput}
-					rows={5}
-					spellcheck="false"
-					class="{controlClass} tags-input min-h-[1.5em] w-full resize-y text-xs"
-					placeholder="One tag per line. Use label&lt;tooltip&gt; for tooltips."
-				></textarea>
 			</div>
 		{/if}
 	</PartCardFrame>
@@ -834,7 +985,10 @@
 		min-width: 5ch;
 	}
 
-	.tags-input {
+	.tag-chip-input {
 		field-sizing: content;
+		width: auto;
+		min-width: 4ch;
+		max-width: 100%;
 	}
 </style>

--- a/src/lib/build-guides/editor/editor.test.ts
+++ b/src/lib/build-guides/editor/editor.test.ts
@@ -51,6 +51,8 @@ describe("build guide serialization", () => {
 				order: 1,
 				color: "success",
 				price: "$29.99",
+				image: "tbs-source-one.jpg",
+				imageAlt: "TBS Source One frame viewed from above",
 				tags: ["30x30<Mounting>"],
 				body: "Durable frame."
 			})
@@ -62,6 +64,8 @@ describe("build guide serialization", () => {
 				"order: 1",
 				"color: success",
 				"price: $29.99",
+				"image: tbs-source-one.jpg",
+				"imageAlt: TBS Source One frame viewed from above",
 				"tags:",
 				'  - "30x30<Mounting>"',
 				"---",


### PR DESCRIPTION
## Summary
- Move infrequently used part fields into a responsive two-column settings dialog.
- Add direct image downloads from public URLs, editable image alt text, and validated slug overrides.
- Preserve existing slugs during title edits and keep image filenames stable when a part is renamed.
- Document direct image URL downloads and cover image metadata serialization.

## Testing
- `bun run check`
- `bun test` (38 passed)
- `bun run build`
- `bunx eslint src/components/build-guides/editor/EditablePartCard.svelte src/lib/build-guides/editor/editor.test.ts`
- Targeted Prettier checks passed. Full `bun run lint` remains blocked by an unrelated pre-existing formatting issue in `src/lib/search/engine.test.ts`.